### PR TITLE
The meta can contain duplicate keys

### DIFF
--- a/meta.js
+++ b/meta.js
@@ -25,7 +25,7 @@ function meta(md, state, start, end, silent) {
 
   if (line >= end) return false
 
-  md.meta = YAML.safeLoad(data.join('\n')) || {};
+  md.meta = YAML.safeLoad(data.join('\n'), {json: true}) || {};
 
   state.line = line + 1
   return true


### PR DESCRIPTION
According to the github's behavior ref: [duplicate key](https://github.com/yuwzho/Test/blob/master/yaml/duplicate-key.md)
